### PR TITLE
rename route 'add' => 'create

### DIFF
--- a/src/Controller/CypressCakeController.php
+++ b/src/Controller/CypressCakeController.php
@@ -85,7 +85,7 @@ class CypressCakeController extends AppController
      *
      * @return \Cake\Http\Response
      */
-    public function add(): Response
+    public function create(): Response
     {
         $data = $this->getRequest()->getData();
 

--- a/src/CypressCakePlugin.php
+++ b/src/CypressCakePlugin.php
@@ -57,7 +57,7 @@ class CypressCakePlugin extends BasePlugin
                     ['controller' => 'CypressCake', 'action' => 'csrfToken'],
                     'cypress-cake.csrf-token',
                 );
-                $builder->post('/add', ['controller' => 'CypressCake', 'action' => 'add'], 'cypress-cake.add');
+                $builder->post('/create', ['controller' => 'CypressCake', 'action' => 'create'], 'cypress-cake.create');
                 $builder->post('/cake', ['controller' => 'CypressCake', 'action' => 'cake'], 'cypress-cake.cake');
             }
         );

--- a/src/support/cypress-commands.js
+++ b/src/support/cypress-commands.js
@@ -75,7 +75,7 @@ Cypress.Commands.add('getCsrfToken', (params) => {
  * cy.create('User')
  * cy.create('User', {email: 'example@example.com'})
  */
-Cypress.Commands.add('add', (params, attributes) => {
+Cypress.Commands.add('create', (params, attributes) => {
   if (typeof params === 'string') {
     params = { factory: params }
     params.attributes = attributes

--- a/tests/Controller/CypressControllerTest.php
+++ b/tests/Controller/CypressControllerTest.php
@@ -112,7 +112,7 @@ class CypressControllerTest extends TestCase
         $this->assertCount(0, $users->find());
 
         $this->enableCsrfToken();
-        $this->post('/cypress/add', [
+        $this->post('/cypress/create', [
           'factory' => 'User',
         ]);
         $this->assertResponseOk();
@@ -129,7 +129,7 @@ class CypressControllerTest extends TestCase
         $userCount = $users->find()->count();
 
         $this->enableCsrfToken();
-        $this->post('/cypress/add', [
+        $this->post('/cypress/create', [
           'factory' => 'User',
           'attributes' => ['email' => $email = 'foobar@example.com'],
         ]);
@@ -147,7 +147,7 @@ class CypressControllerTest extends TestCase
     public function test_it_throws_an_exception_if_the_factory_does_not_exist(): void
     {
         $this->enableCsrfToken();
-        $this->post('/cypress/add', [
+        $this->post('/cypress/create', [
           'factory' => 'FooBar',
         ]);
         $this->assertResponseCode(400);


### PR DESCRIPTION
This PR moves the `add` route to `create` to match the example.