### PR TITLE
fix for custom cake4 project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "tyler36/cypress-cake",
     "description": "Cypress plugin for CakePHP",
     "type": "cakephp-plugin",
-    "version": "1.2",
+    "version": "1.2.1",
     "license": "MIT",
     "require": {
         "php": "^7.4|^8.1",

--- a/src/CypressCakePlugin.php
+++ b/src/CypressCakePlugin.php
@@ -59,9 +59,10 @@ class CypressCakePlugin extends BasePlugin
                 );
                 $builder->post('/create', ['controller' => 'CypressCake', 'action' => 'create'], 'cypress-cake.create');
                 $builder->post('/cake', ['controller' => 'CypressCake', 'action' => 'cake'], 'cypress-cake.cake');
+
+                $builder->fallbacks();
             }
         );
-        parent::routes($routes);
     }
 
     /**


### PR DESCRIPTION
## Issue

Local dev project is able to see routes, but always returns a 404 when trying to access them.

Unsure why the dev project fails to load routes but vanilla projects do,

## Solution

After debugging, the changes in the PR allows the dev project to function as expected.

Test past locally too.