### PR TITLE
Hide "getCsrfToken" from cypress UI output

### DIFF
--- a/src/support/cypress-commands.js
+++ b/src/support/cypress-commands.js
@@ -61,6 +61,7 @@ Cypress.Commands.add('getCsrfToken', (params) => {
     .request({
       method: 'GET',
       url: '/cypress/csrf-token', // Use any page that returns a CSRF token
+      log: false,
     })
     .then((response) => response.body.csrfToken)
 })


### PR DESCRIPTION
This PR reduces some "noise" in the logs.

Fixes #17