### PR TITLE
refactor: `clearDatabase` route move from GET to POST request

### DIFF
--- a/src/CypressCakePlugin.php
+++ b/src/CypressCakePlugin.php
@@ -42,7 +42,7 @@ class CypressCakePlugin extends BasePlugin
             'Tyler36/CypressCake',
             ['path' => '/cypress'],
             function (RouteBuilder $builder): void {
-                $builder->get(
+                $builder->post(
                     '/clear-database',
                     ['controller' => 'CypressCake','action' => 'clearDatabase'],
                     'cypress-cake.clear-database'

--- a/src/support/cypress-commands.js
+++ b/src/support/cypress-commands.js
@@ -20,14 +20,17 @@ Cypress.Commands.overwrite('request', (originalFn, ...args) => {
  * cy.clearDatabase()
  */
 Cypress.Commands.add('clearDatabase', (params) => {
-  return cy
-    .request({
-      method: 'GET',
-      url: '/cypress/clear-database',
-      body: params,
-      log: true,
-    })
-    .its('body', { log: false })
+  return cy.getCsrfToken().then((csrfToken) => {
+    return cy
+      .request({
+        method: 'POST',
+        url: '/cypress/clear-database',
+        log: true,
+        headers: {
+          'X-CSRF-Token': csrfToken,
+        },
+      })
+  })
 })
 
 /**

--- a/tests/Controller/CypressControllerTest.php
+++ b/tests/Controller/CypressControllerTest.php
@@ -36,7 +36,8 @@ class CypressControllerTest extends TestCase
         $this->assertCount(1, $users->find());
 
         // Clear the database.
-        $this->get('/cypress/clear-database');
+        $this->enableCsrfToken();
+        $this->post('/cypress/clear-database');
         $this->assertResponseOk();
         $this->assertCount(0, $users->find());
 

--- a/tests/testdata/cypress/e2e/test.cy.js
+++ b/tests/testdata/cypress/e2e/test.cy.js
@@ -1,7 +1,7 @@
 describe('Cypress-cake', () => {
   it('manages the database', () => {
     cy.clearDatabase().then((response) => {
-      expect(response.data).to.equal(true)
+      expect(response.body.data).to.equal(true)
     })
     cy.visit('/users')
     cy.get('table').should('not.contain', 'now@example.com')


### PR DESCRIPTION
breaking: '/cypress/clear-database' route change

This PR moves `cypress/clear-database` route to a POST request.
This adds additional protection to a route, such as CSRF.
This is probably a good thing given the route is designed to _DELETE_ the database.
