### PR TITLE
feat: config cypress test for PHPunit

### DIFF
--- a/tests/test.bats
+++ b/tests/test.bats
@@ -114,11 +114,9 @@ setupCakePhp() {
   # Install cypress-cake by setting the preferred path and installing it from there.
   composer config repositories."$(basename "$DIR")" "{\"type\": \"path\", \"url\": \"$DIR\", \"options\": {\"symlink\": false}}" --file composer.json
   composer require tyler36/cypress-cake
-
-  # Copy additional settings for PHPunit environment
-  cp "$DIR"/tests/testdata/* ${TESTDIR}/ -r
   ddev cake plugin load Tyler36/CypressCake
 
+  # Install Cypress-included
   ddev addon get tyler36/ddev-cypress
   ddev restart
 


### PR DESCRIPTION
## Issue

When debugging the Cypress BATS tests, I noticed that the I was unable to run PHPunit tests. The tests does not need this configured because it uses the default database for Cypress. However, its nice to be able to run PHPunit to confirm everything is working on the PHP side.

## Solution

This PR configures the test database in the "headless cypress" BATS test.

There is is also minor "cleanup".