### PR TITLE
feat: capture artifacts from CI

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -31,3 +31,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           addon_repository: ${{ env.GITHUB_REPOSITORY }}
           addon_ref: ${{ env.GITHUB_REF }}
+
+      - name: '☁️ Archive artifacts'
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs
+          path: |
+            logs

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -33,8 +33,9 @@ jobs:
           addon_ref: ${{ env.GITHUB_REF }}
 
       - name: '☁️ Archive artifacts'
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: logs
+          name: artifacts
           path: |
-            logs
+            logs/*

--- a/logs/.gitignore
+++ b/logs/.gitignore
@@ -1,0 +1,1 @@
+!.gitignore

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -17,6 +17,9 @@ health_checks() {
 teardown() {
   set -eu -o pipefail
 
+  # Copy any logs to a central area
+  cp -rf ${TESTDIR}/logs ${DIR}/logs/
+
   cd ${TESTDIR} || (printf "unable to cd to ${TESTDIR}\n" && exit 1)
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1
   [ "${TESTDIR}" != "" ] && rm -rf ${TESTDIR}

--- a/tests/testdata/cypress.config.js
+++ b/tests/testdata/cypress.config.js
@@ -4,4 +4,8 @@ module.exports = {
       // implement node event listeners here
     },
   },
+  screenshotOnRunFailure: true,
+  screenshotsFolder: 'logs/e2e/screenshots',
+  video: true,
+  videosFolder: 'logs/e2e/videos',
 };


### PR DESCRIPTION
The PR configures Cypress to

- save screenshots from failed tests.
- save video from failed tests.

Media is saved to `logs/e2e` and these artifacts are save in the CI for debugging.

Fixes #11